### PR TITLE
Updated scala version to 2.11.7 and lift to 2.6.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,12 @@ version := "1.1.2-SNAPSHOT"
 
 organization := "me.frmr.newrelic"
 
-scalaVersion := "2.11.0"
+scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.4", "2.11.0")
+crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.4", "2.11.7")
 
 libraryDependencies ++= {
-  val liftVersion = "2.6-RC1"
+  val liftVersion = "2.6.2"
   Seq(
     "net.liftweb"               %% "lift-webkit"      % liftVersion     % "compile",
     "com.newrelic.agent.java"   % "newrelic-api"      % "3.8.+"


### PR DESCRIPTION
Hi Matt,

I've been ignoring SBT library conflict warnings for a while, but decided to get to the bottom of them today. Here is an example of the conflict I was getting:

[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  \* net.liftweb:lift-webkit_2.11:2.6-RC1 -> 2.6.2 (caller: Insane Logic Limited:ui_2.11:1.0.0, me.frmr.newrelic:lift-newrelic_2.11:1.1.1)

So I have forked your project and updated Scala and liftweb to their latest stable versions. Would be great if you could push this out as version 1.1.2.

Regards,

Andrew
