### PR TITLE
Updated newrelic java agent to a version that fixes security issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "lift-newrelic"
 
-version := "1.1.2-SNAPSHOT"
+version := "1.1.3-SNAPSHOT"
 
 organization := "me.frmr.newrelic"
 
@@ -12,7 +12,7 @@ libraryDependencies ++= {
   val liftVersion = "2.6.2"
   Seq(
     "net.liftweb"               %% "lift-webkit"      % liftVersion     % "compile",
-    "com.newrelic.agent.java"   % "newrelic-api"      % "3.8.+"
+    "com.newrelic.agent.java"   % "newrelic-api"      % "3.30.+"
   )
 }
 


### PR DESCRIPTION
Updated newrelic java agent to a version that fixes security issue:

"Dear valued customer,

New Relic has identified an issue that affects customers using the Java agent 3.6.0 or later when used with Apache HttpClient 4.0 or later, which inadvertently causes the full URI of external web calls (including HTTP request parameters), to be sent to New Relic within a transaction trace. This may include sensitive information if such information is included in your external service call request parameters.

If your application(s) meet the above conditions, please upgrade to Java agent version 3.30.1 which contains a fix."
